### PR TITLE
Ie update status restrictions

### DIFF
--- a/BugTracker.Core/Bug.cs
+++ b/BugTracker.Core/Bug.cs
@@ -26,7 +26,29 @@
             if (newStatus == Status)
                 throw new ArgumentException("Status is already set to the same value.");
             else
-                Status = newStatus;
+            {
+                switch (newStatus)
+                {
+                    case BugStatus.Closed:
+                        if (Status == BugStatus.InProgress || Status == BugStatus.Pending)
+                        {
+                            Status = newStatus;
+                        }
+                        break;
+                    case BugStatus.InProgress:
+                        if (Status == BugStatus.Open || Status == BugStatus.Pending)
+                        {
+                            Status = newStatus;
+                        }
+                        break;
+                    case BugStatus.Pending:
+                        if (Status == BugStatus.InProgress)
+                        {
+                            Status = newStatus;
+                        }
+                        break;
+                }
+            }
         }
 
         public void UpdateAssignedToDeveloper(string developer)
@@ -38,7 +60,7 @@
     {
         Open,
         InProgress,
-        Resolved,
+        Pending,
         Closed
     }
 }

--- a/BugTracker.Tests/BugTests.cs
+++ b/BugTracker.Tests/BugTests.cs
@@ -25,11 +25,11 @@
             Assert.Equal(BugStatus.InProgress, bug.Status);
         }
         [Fact]
-        public void UpdateStatusTestResolved()
+        public void UpdateStatusTestPending()
         {
-            Bug bug = new Bug(3, "Resolved", "Tests Resolved status");
+            Bug bug = new Bug(3, "Pending", "Tests Pending status");
             bug.UpdateStatus((BugStatus)2);
-            Assert.Equal(BugStatus.Resolved, bug.Status);
+            Assert.Equal(BugStatus.Pending, bug.Status);
         }
         [Fact]
         public void UpdateStatusTestClosed()
@@ -71,10 +71,10 @@
             var bug = new Bug(6, "Icon missing", "Settings icon not visible");
 
             // Act
-            bug.UpdateStatus(BugStatus.Resolved);
+            bug.UpdateStatus(BugStatus.InProgress);
 
             // Assert
-            Assert.Equal((BugStatus)2, bug.Status);
+            Assert.Equal((BugStatus)1, bug.Status);
         }
 
         [Fact]
@@ -84,7 +84,7 @@
             var bug = new Bug(8, "Icon missing", "Settings icon not visible");
             var initialStatus = bug.Status;
             // Act
-            bug.UpdateStatus(BugStatus.Resolved);
+            bug.UpdateStatus(BugStatus.InProgress);
 
             // Assert
             Assert.NotEqual(initialStatus, bug.Status);
@@ -97,16 +97,50 @@
         [InlineData(3)]
         public void UpdateStatus_ToSameStatus_ThrowsArgumentException(int status)
         {
-            if (status == 0)
+            switch (status)
             {
-                // Arrange
-                var bug = new Bug(7, "StatusTest", "Status must change to a new status when updated");
-                // Act
-                var ex = Assert.Throws<ArgumentException>(() => bug.UpdateStatus((BugStatus)status));
-                // Assert
-                Assert.True(ex.Message == "Status is already set to the same value.");
+                case 0:
+                    // Arrange
+                    var bug0 = new Bug(7, "StatusTest", "Status must change to a new status when updated");
+                    // Act
+                    var ex0 = Assert.Throws<ArgumentException>(() => bug0.UpdateStatus((BugStatus)status));
+                    // Assert
+                    Assert.Equal("Status is already set to the same value.", ex0.Message);
+                    break;
+                case 1:
+                    // Arrange
+                    var bug1 = new Bug(7, "StatusTest", "Status must change to a new status when updated");
+                    // Assignes the bug status to the same value as the one being tested
+                    bug1.UpdateStatus((BugStatus)status);
+                    // Act
+                    var ex1 = Assert.Throws<ArgumentException>(() => bug1.UpdateStatus((BugStatus)status));
+                    // Assert
+                    Assert.Equal("Status is already set to the same value.", ex1.Message);
+                    break;
+                case 2:
+                    // Arrange
+                    var bug2 = new Bug(7, "StatusTest", "Status must change to a new status when updated");
+                    // Assignes the bug status to the same value as the one being tested
+                    bug2.UpdateStatus((BugStatus)1);
+                    bug2.UpdateStatus((BugStatus)status);
+                    // Act
+                    var ex2 = Assert.Throws<ArgumentException>(() => bug2.UpdateStatus((BugStatus)status));
+                    // Assert
+                    Assert.Equal("Status is already set to the same value.", ex2.Message);
+                    break;
+                case 3:
+                    // Arrange
+                    var bug3 = new Bug(7, "StatusTest", "Status must change to a new status when updated");
+                    // Assignes the bug status to the same value as the one being tested
+                    bug3.UpdateStatus((BugStatus)1);
+                    bug3.UpdateStatus((BugStatus)2);
+                    bug3.UpdateStatus((BugStatus)status);
+                    // Act
+                    var ex3 = Assert.Throws<ArgumentException>(() => bug3.UpdateStatus((BugStatus)status));
+                    // Assert
+                    Assert.Equal("Status is already set to the same value.", ex3.Message);
+                    break;
             }
-            else
             {
                 // Arrange
                 var bug = new Bug(7, "StatusTest", "Status must change to a new status when updated");
@@ -138,6 +172,69 @@
             bug.UpdateAssignedToDeveloper(developerName);
             // Assert
             Assert.Equal(developerName, bug.AssignedToDeveloper);
+        }
+        [Fact]
+        public void StatusChange_OpenToInProgress_ShouldChange()
+        {
+            // Arrange
+            var bug = new Bug(10, "OpenToInProgress", "Should succeed");
+
+            // Act
+            bug.UpdateStatus(BugStatus.InProgress);
+
+            // Assert
+            Assert.Equal(BugStatus.InProgress, bug.Status);
+        }
+
+        [Theory]
+        [InlineData(BugStatus.Pending)]
+        [InlineData(BugStatus.Closed)]
+        public void StatusChange_InProgressToPendingOrClosed_ShouldChange(BugStatus bugStatus)
+        {
+            // Arrange
+            var bug = new Bug(11, "InProgressToPendingOrClosed", "Should succeed");
+
+            // Act
+            bug.UpdateStatus(BugStatus.InProgress);
+            bug.UpdateStatus(bugStatus);
+
+            // Assert
+            Assert.Equal(bugStatus, bug.Status);
+        }
+
+        [Theory]
+        [InlineData(BugStatus.InProgress)]
+        [InlineData(BugStatus.Closed)]
+        public void StatusChange_PendingToInProgressOrClosed_ShouldChange(BugStatus bugStatus)
+        {
+            // Arrange
+            var bug = new Bug(12, "PendingToInProgressOrClosed", "Should succeed");
+
+            // Act
+            bug.UpdateStatus(BugStatus.InProgress);
+            bug.UpdateStatus(BugStatus.Pending);
+            bug.UpdateStatus(bugStatus);
+
+            // Assert
+            Assert.Equal(bugStatus, bug.Status);
+        }
+
+        [Theory]
+        [InlineData(BugStatus.Open)]
+        [InlineData(BugStatus.Pending)]
+        public void StatusChange_ClosedToOpenOrPending_ShouldNotChange(BugStatus bugStatus)
+        {
+            // Arrange
+            var bug = new Bug(13, "ClosedToOpenOrPending", "Should not succeed");
+
+            // Act
+            bug.UpdateStatus(BugStatus.InProgress);
+            bug.UpdateStatus(BugStatus.Pending);
+            bug.UpdateStatus(BugStatus.Closed);
+            bug.UpdateStatus(bugStatus);
+
+            // Assert
+            Assert.Equal(BugStatus.Closed, bug.Status);
         }
     }
 }

--- a/BugTracker.Tests/BugTests.cs
+++ b/BugTracker.Tests/BugTests.cs
@@ -10,14 +10,6 @@
             Assert.IsType<Bug>(bug);
         }
         [Fact]
-        public void UpdateStatusTestOpen()
-        {
-            Bug bug = new Bug(1, "Open", "Tests Open status");
-            bug.UpdateStatus((BugStatus)1);
-            bug.UpdateStatus((BugStatus)0);
-            Assert.Equal(BugStatus.Open, bug.Status);
-        }
-        [Fact]
         public void UpdateStatusTestInProgress()
         {
             Bug bug = new Bug(2, "InProgress", "Tests InProgress status");
@@ -28,6 +20,7 @@
         public void UpdateStatusTestPending()
         {
             Bug bug = new Bug(3, "Pending", "Tests Pending status");
+            bug.UpdateStatus((BugStatus)1);
             bug.UpdateStatus((BugStatus)2);
             Assert.Equal(BugStatus.Pending, bug.Status);
         }
@@ -35,6 +28,7 @@
         public void UpdateStatusTestClosed()
         {
             Bug bug = new Bug(4, "Closed", "Tests Closed status");
+            bug.UpdateStatus((BugStatus)1);
             bug.UpdateStatus((BugStatus)3);
             Assert.Equal(BugStatus.Closed, bug.Status);
         }
@@ -140,16 +134,6 @@
                     // Assert
                     Assert.Equal("Status is already set to the same value.", ex3.Message);
                     break;
-            }
-            {
-                // Arrange
-                var bug = new Bug(7, "StatusTest", "Status must change to a new status when updated");
-                // Assignes the bug status to the same value as the one being tested
-                bug.UpdateStatus((BugStatus)status);
-                // Act
-                var ex = Assert.Throws<ArgumentException>(() => bug.UpdateStatus((BugStatus)status));
-                // Assert
-                Assert.Equal("Status is already set to the same value.", ex.Message);
             }
         }
 


### PR DESCRIPTION
Update status has been updated to function under the following parameters:

Write a test that checks invalid status transitions, such as:
    Attempting to change a bug from Closed back to Open
Write tests for valid transitions as well:
    Open → InProgress
    InProgress → Pending or Closed
    Pending → InProgress or Closed