### PR TITLE
Added CloseTime Feature and adjusted UpdateStatus Service

### DIFF
--- a/BugTracker.Core/Bug.cs
+++ b/BugTracker.Core/Bug.cs
@@ -11,9 +11,13 @@
         public BugStatus Status { get; private set; }
         public string? AssignedToDeveloper { get; set; }
 
+        public DateTime DateCreated { get; } = DateTime.UtcNow; // Automatically sets the date when bug is created
+        public DateTime? DateClosed { get; private set; } // Nullable: Only sets when bug is closed
+
         // Constructor for Bug class, initializes properties and sets default values *
         public Bug(int bugId, string title, string description, int priority, int severity)
         {
+
             BugPriority newPriority;
             BugSeverity newSeverity;
             if (string.IsNullOrWhiteSpace(title))
@@ -29,6 +33,8 @@
             Severity = newSeverity;
             Status = BugStatus.Open;
             AssignedToDeveloper = null;
+
+            DateClosed = null; // Initialize DateClosed to null when bug is created
         }
       
     #region ** Changing Data Methods **
@@ -44,7 +50,10 @@
                     case BugStatus.Closed:
                         if (Status == BugStatus.InProgress || Status == BugStatus.Pending)
                         {
+                  
                             Status = newStatus;
+
+                            DateClosed = DateTime.UtcNow; // Set the date when bug is closed
                         }
                         break;
                     case BugStatus.InProgress:
@@ -112,7 +121,6 @@
             return ($"Bug: {bug.BugId} has been successfully assigned to developer: {bug.AssignedToDeveloper}");
         }
         #endregion
-
     }
 
     #region ** Enums **

--- a/BugTracker.Core/BugService.cs
+++ b/BugTracker.Core/BugService.cs
@@ -10,6 +10,7 @@ namespace BugTracker.Core
     public class BugService
     {
         private readonly List<Bug> _bugs = new List<Bug>(); //Saved bugs in a list
+        private readonly string TZ = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"); // Get the current timezone for display purposes;
 
         public List<Bug> getBugs
         {

--- a/BugTracker.Tests/BugTests.cs
+++ b/BugTracker.Tests/BugTests.cs
@@ -63,8 +63,9 @@
             var ex = Assert.Throws<ArgumentException>(() => new Bug(1, invalidTitle, "desc", 0, 1));
             Assert.Equal("Title cannot be null, empty, or whitespace.", ex.Message);
         }
+
         #endregion
-        
+
         #region ** UpdateStatus Tests **
 
         [Fact]

--- a/BugTracker.Tests/ImprovedTest.cs
+++ b/BugTracker.Tests/ImprovedTest.cs
@@ -87,5 +87,103 @@ namespace BugTracker.Tests
         }
 
         #endregion
+
+        #region **DateTime Tests**
+
+        #region **Constructor Tests**
+        [Fact] // Checks that the bug constructor initializes the DateCreated property to now.
+        public void Constructor_DateCreated_IsSetToNow()
+        {
+            // Arrange
+            var before = DateTime.UtcNow;
+
+            // Act
+            var bug = new Bug(6, "Test", "Test", 0, 1);
+
+            var after = DateTime.UtcNow;
+
+            // Assert
+            Assert.InRange(bug.DateCreated, before, after);
+        }
+        #endregion
+
+        #region **Set Time Tests**
+        [Fact] // Checks that the DateClosed property is null when bug is created.
+        public void Constructor_DateClosed_IsNull()
+        {
+            // Arrange & Act
+            var bug = new Bug(6, "Test", "Test", 0, 1);
+            // Assert
+            Assert.Null(bug.DateClosed);
+        }
+        
+        [Theory] // Validates that DateClosed only sets when status is Closed
+        [InlineData(BugStatus.Pending, false)]
+        [InlineData(BugStatus.InProgress, false)]
+        [InlineData(BugStatus.Closed, true)]
+        public void UpdateStatus_SetsDateClosedOnlyWhenStatusIsClosed(BugStatus status, bool shouldSetDateClosed)
+        {
+            // Arrange
+            var bug = new Bug(6, "Test", "Test", 0, 1);
+
+            // Prepare valid status path before calling the target status
+            if (status == BugStatus.Pending)
+            {
+                bug.UpdateStatus(BugStatus.InProgress);
+            }
+            else if (status == BugStatus.Closed)
+            {
+                bug.UpdateStatus(BugStatus.InProgress);
+                bug.UpdateStatus(BugStatus.Pending);
+            }
+
+            var beforeUpdate = DateTime.UtcNow;
+
+            // Act — apply the actual test status
+            bug.UpdateStatus(status);
+
+            var afterUpdate = DateTime.UtcNow;
+
+            // Assert
+            if (shouldSetDateClosed)
+            {
+                Assert.Equal(BugStatus.Closed, bug.Status);
+                Assert.NotNull(bug.DateClosed);
+                Assert.InRange(bug.DateClosed.Value, beforeUpdate, afterUpdate);
+            }
+            else
+            {
+                Assert.NotEqual(BugStatus.Closed, bug.Status); // Sanity check
+                Assert.Null(bug.DateClosed);
+            }
+        }
+
+        #endregion
+
+        #region **Close Time Tests**
+        [Fact] // Checks that the DateClosed property is set when bug is closed.
+        public void UpdateStatus_Closed_SetsDateClosed()
+        {
+            // Arrange
+            var bug = new Bug(6, "Test", "Test", 0, 1);
+
+            bug.UpdateStatus(BugStatus.InProgress); // Valid transition from Open
+            bug.UpdateStatus(BugStatus.Pending);    // Valid transition from InProgress
+
+            var before = DateTime.UtcNow;
+
+            // Act
+            bug.UpdateStatus(BugStatus.Closed);     // Valid transition from Pending
+
+            var after = DateTime.UtcNow;
+
+            // Assert
+            Assert.Equal(BugStatus.Closed, bug.Status);
+            Assert.NotNull(bug.DateClosed);
+            Assert.InRange(bug.DateClosed.Value, before, after);
+        }
+        #endregion
+
+        #endregion
     }
 }


### PR DESCRIPTION
Added CreateTime and CloseTime Variables to the model package. Set CreateTime to automatically update and create on bug creation. Set CloseTime to be null con creation.

Adjusted UpdateStatus to incorporate changing CloseTime to set the time to Now at that interval.

Built 4 Unit Tests
One to test if the CreateTime populates correctly. 
One to test that CloseTime is set to null correctly. 
One is to ensure that Close only changes when the bug is set to 'close.' 
One is to make sure that the close populates correctly.